### PR TITLE
Update Program.cs

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
@@ -9,7 +9,6 @@ using static System.StringComparison;
 
 namespace SosfmtMsgBin {
     internal static class Program {
-        // <PackageReference Include="Linear" Version="0.2.3"/>
         private const string InFmt = @"main{
     int firstOff 0;
     $value count firstOff/4;
@@ -61,33 +60,36 @@ str {
         }
 
         private static int ExtractFile(string file, string outDir) {
-            var arr = File.ReadAllBytes(file);
-            var fn = Path.GetFileNameWithoutExtension(file);
-            Console.WriteLine($"{fn}...");
-            var count = BinaryPrimitives.ReadInt32LittleEndian(arr) / 4;
-            var settings = new XmlWriterSettings {NewLineChars = "\n", Indent = true};
-            using var writer = XmlWriter.Create(File.CreateText(Path.Combine(outDir, $"{fn}.xml")), settings);
-            writer.WriteStartElement("Entries");
-            writer.WriteAttributeString("Count", count.ToString());
-            //var xml = new XElement("Entries", new XAttribute("Count", count));
-            for (var i = 0; i < count; i++) {
-                writer.WriteStartElement("Entry");
-                var offset = BinaryPrimitives.ReadInt32LittleEndian(arr.AsSpan(i * 4, 4));
-                var next = i + 1 == count
-                    ? arr.Length
-                    : BinaryPrimitives.ReadInt32LittleEndian(arr.AsSpan((i + 1) * 4, 4));
-                var text = Encoding.Unicode.GetString(arr, offset, next - offset - 2);
-                writer.WriteAttributeString("Index", i.ToString());
-                //text = Regex.Replace(text, "<([^>]+)>", "<$1/>");
-                writer.WriteString(text);
-                writer.WriteEndElement();
-                //xml.Add(new XElement("Entry", new XAttribute("Index", i), text));
+            try {
+                var arr = File.ReadAllBytes(file);
+                var fn = Path.GetFileNameWithoutExtension(file);
+                Console.WriteLine($"{fn}...");
+                var count = BinaryPrimitives.ReadInt32LittleEndian(arr) / 4;
+                var settings = new XmlWriterSettings {NewLineChars = "\n", Indent = true};
+
+                using (var writer = XmlWriter.Create(File.CreateText(Path.Combine(outDir, $"{fn}.xml")), settings)) {
+                    writer.WriteStartElement("Entries");
+                    writer.WriteAttributeString("Count", count.ToString());
+
+                    for (var i = 0; i < count; i++) {
+                        writer.WriteStartElement("Entry");
+                        var offset = BinaryPrimitives.ReadInt32LittleEndian(arr.AsSpan(i * 4, 4));
+                        var next = i + 1 == count
+                            ? arr.Length
+                            : BinaryPrimitives.ReadInt32LittleEndian(arr.AsSpan((i + 1) * 4, 4));
+                        var text = Encoding.Unicode.GetString(arr, offset, next - offset - 2);
+                        writer.WriteAttributeString("Index", i.ToString());
+                        writer.WriteString(text);
+                        writer.WriteEndElement();
+                    }
+
+                    writer.WriteEndElement();
+                }
+
+                return 0;
+            } catch (Exception ex) {
+                return CfgFail(1, UsageExtract, $"Error extracting from {file}: {ex.Message}");
             }
-
-            writer.WriteEndElement();
-
-            //xml.WriteTo(writer);
-            return 0;
         }
 
         private static int Pack(IReadOnlyList<string> args) {
@@ -105,33 +107,40 @@ str {
         }
 
         private static int PackFile(string file, string outDir) {
-            var xml = new XmlDocument();
-            xml.Load(file);
-            var fn = Path.GetFileNameWithoutExtension(file);
-            Console.WriteLine($"{fn}...");
-            var root = xml["Entries"];
-            var count = int.Parse(root.GetAttribute("Count"));
-            using var fs = File.Create(Path.Combine(outDir, $"{fn}.bin"));
-            var main = new byte[count * 4];
-            var loc = count * 4;
-            fs.Position = loc;
-            var null2 = new byte[2];
-            foreach (var element in root) {
-                var entry = element as XmlElement;
-                if (entry == null || entry.Name != "Entry") continue;
-                var i = int.Parse(entry.GetAttribute("Index"));
-                BinaryPrimitives.WriteInt32LittleEndian(main.AsSpan(i * 4, 4), loc);
-                var body = entry.InnerText;
-                //body = Regex.Replace(body, "<([^/]+)/>", "<$1>");
-                var bodyArr = Encoding.Unicode.GetBytes(body);
-                fs.Write(bodyArr, 0, bodyArr.Length);
-                fs.Write(null2, 0, 2);
-                loc = (int) fs.Position;
-            }
+            try {
+                var xml = new XmlDocument();
+                xml.Load(file);
+                var fn = Path.GetFileNameWithoutExtension(file);
+                Console.WriteLine($"{fn}...");
+                var root = xml["Entries"];
+                var count = int.Parse(root.GetAttribute("Count"));
 
-            fs.Position = 0;
-            fs.Write(main, 0, main.Length);
-            return 0;
+                using (var fs = File.Create(Path.Combine(outDir, $"{fn}.bin"))) {
+                    var main = new byte[count * 4];
+                    var loc = count * 4;
+                    fs.Position = loc;
+                    var null2 = new byte[2];
+
+                    foreach (var element in root) {
+                        var entry = element as XmlElement;
+                        if (entry == null || entry.Name != "Entry") continue;
+                        var i = int.Parse(entry.GetAttribute("Index"));
+                        BinaryPrimitives.WriteInt32LittleEndian(main.AsSpan(i * 4, 4), loc);
+                        var body = entry.InnerText;
+                        var bodyArr = Encoding.Unicode.GetBytes(body);
+                        fs.Write(bodyArr, 0, bodyArr.Length);
+                        fs.Write(null2, 0, 2);
+                        loc = (int) fs.Position;
+                    }
+
+                    fs.Position = 0;
+                    fs.Write(main, 0, main.Length);
+                }
+
+                return 0;
+            } catch (Exception ex) {
+                return CfgFail(1, UsagePack, $"Error packing from {file}: {ex.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
UTF8 - XmlWriter update - try-catch for errors

Necessario avaliar a melhor maneira de visualizar o erro, da forma que está caso tenha alguma tag com erro o programa fecha rapidamente, talvez usar algo como:

private static int DisplayErrorAndPause(string message) {
    Console.WriteLine(message);
    Console.WriteLine("Press Enter to exit...");
    Console.ReadLine();
    return 1;
}

ou 

catch (Exception ex) {
    CfgFail(1, UsageExtract, $"Error extracting from {file}: {ex.Message}");
    Console.WriteLine("Press Enter to exit...");
    Console.ReadLine();
    return 1;
}

 seja interessante.

--------------
UTF8 - XmlWriter update - try-catch for errors

It is necessary to evaluate the best way to view the error, as it is, if there is any tag with an error, the program closes quickly, perhaps using something like:

private static int DisplayErrorAndPause(string message) {
    Console.WriteLine(message);
    Console.WriteLine("Press Enter to exit...");
    Console.ReadLine();
    return 1;
}

or

catch (Exception ex) {
    CfgFail(1, UsageExtract, $"Error extracting from {file}: {ex.Message}");
    Console.WriteLine("Press Enter to exit...");
    Console.ReadLine();
    return 1;
}


would be interesting.